### PR TITLE
Set producer_consumer as an example for semaphore

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -10,6 +10,7 @@ if GetDepend('KERNEL_SAMPLES_USING_THREAD'):
 
 if GetDepend('KERNEL_SAMPLES_USING_SEMAPHORE'):
     src += ['semaphore_sample.c']
+    src += ['producer_consumer.c']
 
 if GetDepend('KERNEL_SAMPLES_USING_MUTEX'):
     src += ['mutex_sample.c']


### PR DESCRIPTION
生产者-消费者模型是一个使用 semaphore 挺好的例子。
这样在 menuconfig --> online package --> misc pkgs --> samples --> kernel 里选中 semaphore  就可以看到这个例子了